### PR TITLE
hosts.txt - Removing dead and inactive domains

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -25,22 +25,16 @@
 127.0.0.1 lb.usemaxserver.de
 127.0.0.1 tracking.klickthru.com
 127.0.0.1 gsmtop.net
-127.0.0.1 click.buzzcity.net
-127.0.0.1 ads.admoda.com
 127.0.0.1 stats.pflexads.com
 127.0.0.1 a.glcdn.co
 127.0.0.1 wwww.adleads.com
-127.0.0.1 ad.madvertise.de
-127.0.0.1 apps.buzzcity.net
 127.0.0.1 ads.mobgold.com
 127.0.0.1 android.bcfads.com
-127.0.0.1 show.buzzcity.net
 127.0.0.1 api.analytics.omgpop.com
 127.0.0.1 r.edge.inmobicdn.net
 127.0.0.1 www.mmnetwork.mobi
 127.0.0.1 img.ads.huntmad.com
 127.0.0.1 creative1cdn.mobfox.com
-127.0.0.1 admicro2.vcmedia.vn
 127.0.0.1 admicro1.vcmedia.vn
 127.0.0.1 s3.phluant.com
 127.0.0.1 c.vrvm.com
@@ -67,15 +61,11 @@
 127.0.0.1 i.tapit.com
 127.0.0.1 cdn1.crispadvertising.com
 127.0.0.1 cdn2.crispadvertising.com
-127.0.0.1 medrx.sensis.com.au
 127.0.0.1 rs-staticart.ybcdn.net
 127.0.0.1 img.ads.taptapnetworks.com
-127.0.0.1 adserver.ubiyoo.com
 127.0.0.1 c753738.r38.cf2.rackcdn.com
 127.0.0.1 edge.reporo.net
-127.0.0.1 ads.n-ws.org 
 127.0.0.1 adultmoda.com
-127.0.0.1 ads.smartdevicemedia.com
 127.0.0.1 b.scorecardresearch.com
 127.0.0.1 m.adsymptotic.com
 127.0.0.1 cdn.vdopia.com
@@ -91,14 +81,10 @@
 127.0.0.1 gts-ads.twistbox.com
 127.0.0.1 static.cdn.gtsmobi.com
 127.0.0.1 ads.matomymobile.com
-127.0.0.1 ads.adiquity.com
 127.0.0.1 img.ads.mobilefuse.net
 127.0.0.1 as.adfonic.net
 127.0.0.1 media.mobpartner.mobi
-127.0.0.1 cdn.us.goldspotmedia.com
-127.0.0.1 ads2.mediaarmor.com
 127.0.0.1 cdn.nearbyad.com
-127.0.0.1 ads.ookla.com
 127.0.0.1 mobiledl.adobe.com
 127.0.0.1 ads.flurry.com
 127.0.0.1 gemini.yahoo.com
@@ -113,7 +99,6 @@
 127.0.0.1 admin.vserv.mobi
 127.0.0.1 c.vserv.mobi
 127.0.0.1 ads.vserv.mobi
-127.0.0.1 sf.vserv.mobi
 
 # [pflexads.com]
 127.0.0.1 hybl9bazbc35.pflexads.com
@@ -122,7 +107,6 @@
 127.0.0.1 orencia.pflexads.com
 
 # [velti.com]
-127.0.0.1 atti.velti.com
 127.0.0.1 ru.velti.com
 127.0.0.1 mwc.velti.com
 
@@ -176,18 +160,7 @@
 127.0.0.1 r.mobpartner.mobi
 
 # [Adinfuse]
-127.0.0.1 uk-ad2.adinfuse.com
 127.0.0.1 adinfuse.com
-127.0.0.1 go.adinfuse.com
-127.0.0.1 ad1.adinfuse.com
-127.0.0.1 ad2.adinfuse.com
-127.0.0.1 sky.adinfuse.com
-127.0.0.1 orange-fr.adinfuse.com
-127.0.0.1 sky-connect.adinfuse.com
-127.0.0.1 uk-go.adinfuse.com
-127.0.0.1 orangeuk-mc.adinfuse.com
-127.0.0.1 intouch.adinfuse.com
-127.0.0.1 funnel0.adinfuse.com
 
 # [mydas.mobi]
 127.0.0.1 cvt.mydas.mobi
@@ -201,21 +174,6 @@
 
 # [appads.com]
 127.0.0.1 neptune.appads.com
-127.0.0.1 neptune1.appads.com
-127.0.0.1 neptune2.appads.com
-127.0.0.1 neptune3.appads.com
-127.0.0.1 saturn.appads.com
-127.0.0.1 saturn1.appads.com
-127.0.0.1 saturn2.appads.com
-127.0.0.1 saturn3.appads.com
-127.0.0.1 jupiter.appads.com
-127.0.0.1 jupiter1.appads.com
-127.0.0.1 jupiter2.appads.com
-127.0.0.1 jupiter3.appads.com
-127.0.0.1 req.appads.com
-127.0.0.1 req1.appads.com
-127.0.0.1 req2.appads.com
-127.0.0.1 req3.appads.com
 
 # [yandex.ru]
 127.0.0.1 mc.yandex.ru
@@ -249,125 +207,6 @@
 
 # [smaato.net]
 127.0.0.1 soma.smaato.net
-127.0.0.1 c29new.smaato.net
-127.0.0.1 c01.smaato.net
-127.0.0.1 c02.smaato.net
-127.0.0.1 c03.smaato.net
-127.0.0.1 c04.smaato.net
-127.0.0.1 c05.smaato.net
-127.0.0.1 c06.smaato.net
-127.0.0.1 c07.smaato.net
-127.0.0.1 c08.smaato.net
-127.0.0.1 c09.smaato.net
-127.0.0.1 c10.smaato.net
-127.0.0.1 c11.smaato.net
-127.0.0.1 c12.smaato.net
-127.0.0.1 c13.smaato.net
-127.0.0.1 c14.smaato.net
-127.0.0.1 c15.smaato.net
-127.0.0.1 c16.smaato.net
-127.0.0.1 c17.smaato.net
-127.0.0.1 c18.smaato.net
-127.0.0.1 c19.smaato.net
-127.0.0.1 c20.smaato.net
-127.0.0.1 c21.smaato.net
-127.0.0.1 c22.smaato.net
-127.0.0.1 c23.smaato.net
-127.0.0.1 c24.smaato.net
-127.0.0.1 c25.smaato.net
-127.0.0.1 c26.smaato.net
-127.0.0.1 c27.smaato.net
-127.0.0.1 c28.smaato.net
-127.0.0.1 c29.smaato.net
-127.0.0.1 c30.smaato.net
-127.0.0.1 c31.smaato.net
-127.0.0.1 c32.smaato.net
-127.0.0.1 c33.smaato.net
-127.0.0.1 c34.smaato.net
-127.0.0.1 c35.smaato.net
-127.0.0.1 c36.smaato.net
-127.0.0.1 c37.smaato.net
-127.0.0.1 c38.smaato.net
-127.0.0.1 c39.smaato.net
-127.0.0.1 c40.smaato.net
-127.0.0.1 c41.smaato.net
-127.0.0.1 c42.smaato.net
-127.0.0.1 c43.smaato.net
-127.0.0.1 c44.smaato.net
-127.0.0.1 c45.smaato.net
-127.0.0.1 c46.smaato.net
-127.0.0.1 c47.smaato.net
-127.0.0.1 c48.smaato.net
-127.0.0.1 c49.smaato.net
-127.0.0.1 c50.smaato.net
-127.0.0.1 c51.smaato.net
-127.0.0.1 c52.smaato.net
-127.0.0.1 c53.smaato.net
-127.0.0.1 c54.smaato.net
-127.0.0.1 c55.smaato.net
-127.0.0.1 c56.smaato.net
-127.0.0.1 c57.smaato.net
-127.0.0.1 c58.smaato.net
-127.0.0.1 c59.smaato.net
-127.0.0.1 c60.smaato.net
-127.0.0.1 f03.smaato.net
-127.0.0.1 f04.smaato.net
-127.0.0.1 f05.smaato.net
-127.0.0.1 f06.smaato.net
-127.0.0.1 f07.smaato.net
-127.0.0.1 f08.smaato.net
-127.0.0.1 f09.smaato.net
-127.0.0.1 f10.smaato.net
-127.0.0.1 f11.smaato.net
-127.0.0.1 f12.smaato.net
-127.0.0.1 f13.smaato.net
-127.0.0.1 f14.smaato.net
-127.0.0.1 f15.smaato.net
-127.0.0.1 f16.smaato.net
-127.0.0.1 f17.smaato.net
-127.0.0.1 f18.smaato.net
-127.0.0.1 f19.smaato.net
-127.0.0.1 f20.smaato.net
-127.0.0.1 f21.smaato.net
-127.0.0.1 f22.smaato.net
-127.0.0.1 f23.smaato.net
-127.0.0.1 f24.smaato.net
-127.0.0.1 f25.smaato.net
-127.0.0.1 f26.smaato.net
-127.0.0.1 f27.smaato.net
-127.0.0.1 f28.smaato.net
-127.0.0.1 f29.smaato.net
-127.0.0.1 f30.smaato.net
-127.0.0.1 f31.smaato.net
-127.0.0.1 f32.smaato.net
-127.0.0.1 f33.smaato.net
-127.0.0.1 f34.smaato.net
-127.0.0.1 f35.smaato.net
-127.0.0.1 f36.smaato.net
-127.0.0.1 f37.smaato.net
-127.0.0.1 f38.smaato.net
-127.0.0.1 f39.smaato.net
-127.0.0.1 f40.smaato.net
-127.0.0.1 f41.smaato.net
-127.0.0.1 f42.smaato.net
-127.0.0.1 f43.smaato.net
-127.0.0.1 f44.smaato.net
-127.0.0.1 f45.smaato.net
-127.0.0.1 f46.smaato.net
-127.0.0.1 f47.smaato.net
-127.0.0.1 f48.smaato.net
-127.0.0.1 f49.smaato.net
-127.0.0.1 f50.smaato.net
-127.0.0.1 f51.smaato.net
-127.0.0.1 f52.smaato.net
-127.0.0.1 f53.smaato.net
-127.0.0.1 f54.smaato.net
-127.0.0.1 f55.smaato.net
-127.0.0.1 f56.smaato.net
-127.0.0.1 f57.smaato.net
-127.0.0.1 f58.smaato.net
-127.0.0.1 f59.smaato.net
-127.0.0.1 f60.smaato.net
 
 # [mojiva.com]
 127.0.0.1 img.ads1.mojiva.com
@@ -391,7 +230,6 @@
 127.0.0.1 im2.smartadserver.com
 127.0.0.1 itx5-publicidad.smartadserver.com
 127.0.0.1 itx5.smartadserver.com
-127.0.0.1 tcy.smartadserver.com
 127.0.0.1 ww129.smartadserver.com
 127.0.0.1 ww13.smartadserver.com
 127.0.0.1 ww14.smartadserver.com
@@ -437,15 +275,8 @@
 127.0.0.1 strikeadcdn.s3.amazonaws.com
 
 # [Admob]
-127.0.0.1 a.admob.com
-127.0.0.1 analytics.admob.com
 127.0.0.1 c.admob.com
 127.0.0.1 media.admob.com
-127.0.0.1 p.admob.com
-
-# [AdWhirl]
-127.0.0.1 met.adwhirl.com
-127.0.0.1 mob.adwhirl.com
 
 # [Doubleclick (Google)]
 127.0.0.1 ad-g.doubleclick.net
@@ -455,8 +286,6 @@
 127.0.0.1 googleads.g.doubleclick.net
 
 # [Google]
-127.0.0.1 pagead.googlesyndication.com
-127.0.0.1 pagead1.googlesyndication.com
 127.0.0.1 pagead2.googlesyndication.com
 
 # [National Rail Enquiries, https://play.google.com/store/apps/details?id=uk.co.nationalrail.google]
@@ -489,7 +318,6 @@
 
 # [http://play.google.com/store/apps/details?id=com.taeyang.billboardtop]
 127.0.0.1 st.a-link.co.kr
-127.0.0.1 cdn.ajillionmax.com
 127.0.0.1 dispatch.admixer.co.kr
 127.0.0.1 ifc.inmobi.com
 127.0.0.1 thinknear-hosted.thinknearhub.com
@@ -508,7 +336,6 @@
 127.0.0.1 cdn.creative.medialytics.com
 127.0.0.1 p.medialytics.com
 127.0.0.1 px.cdn.creative.medialytics.com
-127.0.0.1 t.medialytics.com
 
 # [Google]
 127.0.0.1 google-analytics.com


### PR DESCRIPTION
Removed domains:
```
click.buzzcity.net
ads.admoda.com
ad.madvertise.de
apps.buzzcity.net
show.buzzcity.net
admicro2.vcmedia.vn
medrx.sensis.com.au
adserver.ubiyoo.com
ads.n-ws.org
ads.smartdevicemedia.com
ads.adiquity.com
cdn.us.goldspotmedia.com
ads2.mediaarmor.com
ads.ookla.com
sf.vserv.mobi
atti.velti.com
uk-ad2.adinfuse.com
go.adinfuse.com
ad1.adinfuse.com
ad2.adinfuse.com
sky.adinfuse.com
orange-fr.adinfuse.com
sky-connect.adinfuse.com
uk-go.adinfuse.com
orangeuk-mc.adinfuse.com
intouch.adinfuse.com
funnel0.adinfuse.com
neptune.appads.com
neptune1.appads.com
neptune2.appads.com
neptune3.appads.com
saturn.appads.com
saturn1.appads.com
saturn2.appads.com
saturn3.appads.com
jupiter.appads.com
jupiter1.appads.com
jupiter2.appads.com
jupiter3.appads.com
req.appads.com
req1.appads.com
req2.appads.com
req3.appads.com
c29new.smaato.net
c01.smaato.net
c02.smaato.net
c03.smaato.net
c04.smaato.net
c05.smaato.net
c06.smaato.net
c07.smaato.net
c08.smaato.net
c09.smaato.net
c10.smaato.net
c11.smaato.net
c12.smaato.net
c13.smaato.net
c14.smaato.net
c15.smaato.net
c16.smaato.net
c17.smaato.net
c18.smaato.net
c19.smaato.net
c20.smaato.net
c21.smaato.net
c22.smaato.net
c23.smaato.net
c24.smaato.net
c25.smaato.net
c26.smaato.net
c27.smaato.net
c28.smaato.net
c29.smaato.net
c30.smaato.net
c31.smaato.net
c32.smaato.net
c33.smaato.net
c34.smaato.net
c35.smaato.net
c36.smaato.net
c37.smaato.net
c38.smaato.net
c39.smaato.net
c40.smaato.net
c41.smaato.net
c42.smaato.net
c43.smaato.net
c44.smaato.net
c45.smaato.net
c46.smaato.net
c47.smaato.net
c48.smaato.net
c49.smaato.net
c50.smaato.net
c51.smaato.net
c52.smaato.net
c53.smaato.net
c54.smaato.net
c55.smaato.net
c56.smaato.net
c57.smaato.net
c58.smaato.net
c59.smaato.net
f03.smaato.net
f04.smaato.net
f05.smaato.net
f06.smaato.net
f07.smaato.net
f08.smaato.net
f09.smaato.net
f10.smaato.net
f11.smaato.net
f12.smaato.net
f13.smaato.net
f14.smaato.net
f15.smaato.net
f16.smaato.net
f17.smaato.net
f18.smaato.net
f19.smaato.net
f20.smaato.net
f21.smaato.net
f22.smaato.net
f23.smaato.net
f24.smaato.net
f25.smaato.net
f26.smaato.net
f27.smaato.net
f28.smaato.net
f29.smaato.net
f30.smaato.net
f31.smaato.net
f32.smaato.net
f33.smaato.net
f34.smaato.net
f35.smaato.net
f36.smaato.net
f37.smaato.net
f38.smaato.net
f39.smaato.net
f40.smaato.net
f41.smaato.net
f42.smaato.net
f43.smaato.net
f44.smaato.net
f45.smaato.net
f46.smaato.net
f47.smaato.net
f48.smaato.net
f49.smaato.net
f50.smaato.net
f51.smaato.net
f52.smaato.net
f53.smaato.net
f54.smaato.net
f55.smaato.net
f56.smaato.net
f57.smaato.net
f58.smaato.net
f59.smaato.net
f60.smaato.net
tcy.smartadserver.com
a.admob.com
analytics.admob.com
p.admob.com
met.adwhirl.com
mob.adwhirl.com
pagead.googlesyndication.com
pagead1.googlesyndication.com
cdn.ajillionmax.com
t.medialytics.com
```
 Credit to @funilrys / using [funceble](https://github.com/funilrys/funceble).