### PR TITLE
Clarify minimum Android version

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@ Features</p>
 <a id="requirements" class="anchor" href="#requirements" aria-hidden="true"><span class="octicon octicon-link"></span></a>Requirements</h1>
 
 <ul>
-<li>Android version: 2.1</li>
+<li>Android version: 2.1 or above</li>
 <li>ROOT required</li>
 <li>Read/Write access on system-Partition</li>
 </ul>


### PR DESCRIPTION
Viewers skimming the page might miss the first mention that 2.1 is only the minimum. A friend of mine I sent this page to came away thinking AdAway was only for really old phones.