### PR TITLE
Replace miarroba.com with ads.miarroba.com

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -11039,7 +11039,7 @@
 127.0.0.1 g.jp.miaozhen.com
 
 # [miarroba.com]
-127.0.0.1 miarroba.com
+127.0.0.1 ads.miarroba.com
 
 # [microad.jp]
 127.0.0.1 microad.jp


### PR DESCRIPTION
miarroba.com is the main page of the hosting company, which left it inaccessible while not blocking the ads at ads.miarroba.com.