### PR TITLE
Remove sdk.arengu.com

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -3717,9 +3717,6 @@
 127.0.0.1 api.areametrics.com
 127.0.0.1 production-api.areametrics.com
 
-# [arengu.com]
-127.0.0.1 sdk.arengu.com
-
 # [areyouahuman.com]
 127.0.0.1 dptr.areyouahuman.com
 127.0.0.1 n-cdn.areyouahuman.com


### PR DESCRIPTION
Hello,

Arengu is a tool to make forms and connect them with other services, and is not used for tracking or advertising purposes.

Blocking `sdk.arengu.com` makes the forms fail to load. This PR removes it from the list.

Some examples: https://static.playground.arengu.com/

_Disclaimer: I work for Arengu._

Thanks!