### PR TITLE
remove ip-api.com

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -9062,9 +9062,6 @@
 127.0.0.1 ci-mpsnare.iovation.com
 127.0.0.1 first.iovation.com
 
-# [ip-api.com]
-127.0.0.1 ip-api.com
-
 # [ipass.com]
 127.0.0.1 logservices.ipass.com
 127.0.0.1 om-datacollector.ipass.com


### PR DESCRIPTION
looks like is just a standalone ip geolocating api service why is blocked?