### PR TITLE
Remove Gitter Sidecar from blocked hosts

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -7656,9 +7656,6 @@
 127.0.0.1 cdn-prod-defaulting-gamedev-ads.gismart.xyz
 127.0.0.1 prod-defaulting-subscriptiontool.gismart.xyz
 
-# [gitter.im]
-127.0.0.1 sidecar.gitter.im
-
 # [gladly.com]
 127.0.0.1 cdn.gladly.com
 127.0.0.1 production1.gladly.com


### PR DESCRIPTION
Heya Gitter team here 👋 

We're looking to remove [ Gitter Sidecar(`sidecar.gitter.im`)](https://sidecar.gitter.im/) from the adblocking list or get some context on why it was added.

Sidecar allows people to embed their Gitter chat room on their own site. You can checkout an example of what Sidecar does on the demo site (see the "Open chat" button), https://sidecar.gitter.im/

This originally came to our attention when a user reported the site as "down" and recommended we try to get it unblocked, see https://gitter.im/gitter/sidecar?at=5ecd1567a91f120a6cc323d1 

Gitter Sidecar was first added to the blocked host list in https://github.com/AdAway/adaway.github.io/pull/13

We're also tracking this situation on our issue tracker: https://gitlab.com/gitlab-org/gitter/webapp/-/issues/2529
