### PR TITLE
Removes curalate.com domains from blocklist

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -5691,9 +5691,6 @@
 # [cuebiq.com]
 127.0.0.1 in.cuebiq.com
 
-# [curalate.com]
-127.0.0.1 cdn.curalate.com
-
 # [customer.io]
 127.0.0.1 track.customer.io
 
@@ -6755,8 +6752,6 @@
 127.0.0.1 cbola-logging-1-t3.us-east-1.elasticbeanstalk.com
 127.0.0.1 cbola-psa.us-east-1.elasticbeanstalk.com
 127.0.0.1 cloud-graphql-live.us-east-1.elasticbeanstalk.com
-127.0.0.1 curalate-api-prod.us-east-1.elasticbeanstalk.com
-127.0.0.1 curalate-like2buy-prod-vpc.us-east-1.elasticbeanstalk.com
 127.0.0.1 ddm-analystic-pro2.us-east-1.elasticbeanstalk.com
 127.0.0.1 dhg-logging.us-east-1.elasticbeanstalk.com
 127.0.0.1 ei-event-collector.us-east-1.elasticbeanstalk.com


### PR DESCRIPTION
I currently use your blocklist from https://github.com/StevenBlack/hosts and I absolutely love it, but I noticed a few domains on here that break websites associated with the company I work with, Curalate.

`cdn.curalate.com` and `curalate-api-prod.us-east-1.elasticbeanstalk.com` (CNAMEd from api.curalate.com) are used for serving content required to load data on our clients' websites. An example of a broken site would be on https://www.aldoshoes.com/ - the area below `Our #ALDOCrew HomeStyle Inspo` fails to load because of these blocked domains.

`curalate-like2buy-prod-vpc.us-east-1.elasticbeanstalk.com` (CNAMEd from like2buy.curalate.com) is used to show a shoppable Instagram experience which is linked to from our clients' Instagram pages. https://www.instagram.com/jcpenney/?hl=en links to like2b.uy/jcpenney which redirects to https://jcpenney.like2buy.curalate.com/c/gallery/like2buy?id=QCx5BRj4&l=like2buy which CNAMEs to `curalate-like2buy-prod-vpc.us-east-1.elasticbeanstalk.com`. Since the elasticbeanstalk domain is blocked, that site fails to load.

Let me know if you have any further questions or need additional clarification and I'd be more than happy to respond!