### PR TITLE
Added 1 entry for Mediavine.com

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -10740,7 +10740,6 @@
 127.0.0.1 dev-block.mediavenus.com
 
 # [mediavine.com]
-127.0.0.1 mediavine.com
 127.0.0.1 scripts.mediavine.com
 
 # [mediawayss.com]

--- a/hosts.txt
+++ b/hosts.txt
@@ -10735,13 +10735,13 @@
 127.0.0.1 xdssp.mediav.com
 127.0.0.1 zzxd.mediav.com
 
-# [mediavine.com]
-127.0.0.1 mediavine.com
-127.0.0.1 scripts.mediavine.com
-
 # [mediavenus.com]
 127.0.0.1 mediavenus.com
 127.0.0.1 dev-block.mediavenus.com
+
+# [mediavine.com]
+127.0.0.1 mediavine.com
+127.0.0.1 scripts.mediavine.com
 
 # [mediawayss.com]
 127.0.0.1 mediawayss.com

--- a/hosts.txt
+++ b/hosts.txt
@@ -10735,6 +10735,10 @@
 127.0.0.1 xdssp.mediav.com
 127.0.0.1 zzxd.mediav.com
 
+# [mediavine.com]
+127.0.0.1 mediavine.com
+127.0.0.1 scripts.mediavine.com
+
 # [mediavenus.com]
 127.0.0.1 mediavenus.com
 127.0.0.1 dev-block.mediavenus.com


### PR DESCRIPTION
In particular, `127.0.0.1 scripts.mediavine.com` removes large placeholder boxes on `https://matpaabordet.no/2014/04/30/refried-beans-2/`, and is not present in any major hosts or raw-domains lists that I know of. However, since `mediavine.com` is in Peter Lowe's List and AdGuard DNS Filter, I presume the domain is supposed to be blocked on a broad basis.

A listing of more of its subdomains can be found at `https://securitytrails.com/list/apex_domain/mediavine.com`, if you were to find that more of them were used on 3rd-party sites.

Disclosure: This PR is mostly submitted for the sake of Energized Protection (who have a near-monopoly on list inclusion in Blokada) and Steven Black's Hosts, both of which use your list as one of their numerous sources. Peter Lowe's List was my first choice for this request, but he has begun to reject adding subdomains to his list.