### PR TITLE
iadsdk.apple.com

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -2361,6 +2361,14 @@
 # [applanga.com]
 127.0.0.1 sdkapicdn.applanga.com
 
+# [apple.com] 
+127.0.0.1 iadsdk.apple.com
+127.0.0.1 ca.iadsdk.apple.com
+127.0.0.1 cf.iadsdk.apple.com
+127.0.0.1 tr.iadsdk.apple.com
+127.0.0.1 ut.iadsdk.apple.com
+127.0.0.1 banners.itunes.apple.com
+
 # [applicaster.com]
 127.0.0.1 assets-production.applicaster.com
 127.0.0.1 assets-secure.applicaster.com


### PR DESCRIPTION
As mentioned in <https://github.com/AdAway/adaway.github.io/issues/191#issuecomment-727228474> I do not find any evidence this should in any way been confirmed these records brakes anything, and the the user account submitting the claim is all new without any history.

I'll therefore urch you to keep these records until the should be found more reliable sources for confirmation of breakage.

Users should until further evidence have arises be whitelisting and reporting(with logs) that there appz requires SpyWare to run.

Fixes https://github.com/AdAway/adaway.github.io/issues/191