### PR TITLE
Remove adzuna.co.uk from blocklist

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -1650,9 +1650,6 @@
 # [adztec.com]
 127.0.0.1 adztec.com
 
-# [adzuna.co.uk]
-127.0.0.1 adzuna.co.uk
-
 # [aerserv.com]
 127.0.0.1 ads.aerserv.com
 127.0.0.1 alpha-events.aerserv.com


### PR DESCRIPTION
I use your list from a local Pi-hole server through the https://github.com/StevenBlack/hosts list.

Tonight while browsing at home I noticed that I couldn't access the homepage of the company I work for, Adzuna. I think this is an error as the company is a job search engine.

Besides removing the record, it would be really helpful for us to know why the record was included so we can avoid this happening again in the future in this or other blocklists.