### PR TITLE
Remove usersnap

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -12520,10 +12520,6 @@
 # [usekahuna.com]
 127.0.0.1 usekahuna.com
 
-# [usersnap.com]
-127.0.0.1 api.usersnap.com
-127.0.0.1 cdn.usersnap.com
-
 # [utarget.ru]
 127.0.0.1 utarget.ru
 


### PR DESCRIPTION
Usersnap is a tool for users to give feedback about the website. It does not track users unless they write a message and click submit. It also contains no advertisements