### PR TITLE
truecaller.com

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -12291,6 +12291,10 @@
 127.0.0.1 beacon.tru.am
 
 # [truecaller.com]
+127.0.0.1 ads5.truecaller.com
+127.0.0.1 ads5-noneu.truecaller.com
+127.0.0.1 ads-router-noneu.truecaller.com
+127.0.0.0 batchlogging4.truecaller.com
 127.0.0.1 pushid-noneu.truecaller.com
 
 # [trustarc.com]


### PR DESCRIPTION
Closes https://github.com/AdAway/adaway.github.io/issues/218

+ a few from: https://www.mypdns.org/T4265

In addition to #218 I have added
```
batchlogging4.truecaller.com   CNAME . ; Tracking

ads5.truecaller.com   CNAME . ; AdWare
ads-router-noneu.truecaller.com   CNAME . ; AdWare
```