### PR TITLE
Typo AdAway#220

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -12294,12 +12294,8 @@
 127.0.0.1 ads5.truecaller.com
 127.0.0.1 ads5-noneu.truecaller.com
 127.0.0.1 ads-router-noneu.truecaller.com
-127.0.0.0 batchlogging4.truecaller.com
-127.0.0.1 pushid-noneu.truecaller.com
-127.0.0.1 ads5.truecaller.com
-127.0.0.1 ads5-noneu.truecaller.com
-127.0.0.1 ads-router-noneu.truecaller.com
 127.0.0.1 batchlogging4.truecaller.com
+127.0.0.1 pushid-noneu.truecaller.com
 
 # [trustarc.com]
 127.0.0.1 choices.trustarc.com

--- a/hosts.txt
+++ b/hosts.txt
@@ -12236,6 +12236,10 @@
 
 # [truecaller.com]
 127.0.0.1 pushid-noneu.truecaller.com
+127.0.0.1 ads5.truecaller.com
+127.0.0.1 ads5-noneu.truecaller.com
+127.0.0.1 ads-router-noneu.truecaller.com
+127.0.0.1 batchlogging4.truecaller.com
 
 # [trustarc.com]
 127.0.0.1 choices.trustarc.com


### PR DESCRIPTION
I had previously make a typo where i have added `127.0.0.0` instead of the `127.0.0.1` in `batchlogging4.truecaller.com`  this should now have been fixed

Closes https://github.com/AdAway/adaway.github.io/issues/220

Credit:
  - elmaimbo
  - bigdargon