### PR TITLE
Remove Sumo Logic from blocked hosts lists

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -10938,15 +10938,6 @@
 127.0.0.1 filev4.subiz.com
 127.0.0.1 static.subiz.com
 
-# [sumologic.com]
-127.0.0.1 collection.sumologic.com
-127.0.0.1 endpoint2.collection.sumologic.com
-127.0.0.1 collectors.sumologic.com
-127.0.0.1 us2.sumologic.com
-127.0.0.1 collection.us2.sumologic.com
-127.0.0.1 endpoint1.collection.us2.sumologic.com
-127.0.0.1 collectors.us2.sumologic.com
-
 # [sumome.com]
 127.0.0.1 sumome.com
 127.0.0.1 load.sumome.com


### PR DESCRIPTION
Hi AdAway team,

(Full disclosure: I work at Sumo Logic.)

At [Sumo Logic](https://www.sumologic.com/) our focus is "real-time monitoring and security insights for [...] apps and infrastructure". Since our business is not in ads and the reason that people use our software is because they deliberately choose it (installed/configured in their infrastructure), we think our hostnames do not belong on the AdAway hosts.txt list.

I'm happy to answer any questions.
