### PR TITLE
Remove chtbl.com from hosts.txt (closes #243)

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -3379,7 +3379,6 @@
 127.0.0.1 smetrics.chrysler.com
 
 # [chtbl.com]
-127.0.0.1 chtbl.com
 127.0.0.1 ext.chtbl.com
 127.0.0.1 web.chtbl.com
 


### PR DESCRIPTION
Chartable is a podcast analytics service. Blocking chtbl.com prevents downloading or streaming some podcasts in major iOS podcast apps, including Spotify, Overcast, and Pocket Casts.

There are several reports from this year of other users encountering this issue:
* https://www.reddit.com/r/pihole/comments/kspwsh/apple_podcasts_fail_when_they_cant_connect_to/
* https://www.reddit.com/r/pocketcasts/comments/krsiqe/fyi_if_you_use_a_private_dns_server_on_mobile/gibsyh2/
* https://www.reddit.com/r/Adguard/comments/kr2ko8/dnsadguardcom_blocking_some_podcast_downloads/gi7qc83/
* https://www.reddit.com/r/nextdns/comments/krb808/pocketcasts_app_is_blocked_by_nextdns/giahz3u/