### PR TITLE
Remove Intercom

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -6301,12 +6301,6 @@
 127.0.0.1 sync.intentiq.com
 127.0.0.1 sync1.intentiq.com
 
-# [intercom.io]
-127.0.0.1 mobile-sdk-api.intercom.io
-
-# [intercomcdn.com]
-127.0.0.1 js.intercomcdn.com
-
 # [intergi.com]
 127.0.0.1 cdn.intergi.com
 


### PR DESCRIPTION
Hi team, we noticed here at Intercom that we were added to this list.

Intercom is a live chat/support service allowing people to quickly get support online. Blocking those URLs prevents people being able to see the chat widget and reach out for support. We do not provide any advertisements.

It would be great if we could get removed from this list, as those people using it (or downstream of it) are unable to get support across a variety of sites.

Thanks!