### PR TITLE
Removed domain not relevant to ad blocking purposes

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -6581,9 +6581,6 @@
 # [justservingfiles.net]
 127.0.0.1 bmedia.justservingfiles.net
 
-# [jwplayer.com]
-127.0.0.1 entitlements.jwplayer.com
-
 # [jwpsrv.com]
 127.0.0.1 g.jwpsrv.com
 


### PR DESCRIPTION
The entitlements domain being removed would lead to more ads, blocking ti would not prevent ad playback from happening.