### PR TITLE
Add androidtvwatsonfe-pa.googleapis.com

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -5220,6 +5220,7 @@
 127.0.0.1 static.googleadsserving.cn
 
 # [googleapis.com]
+127.0.0.1 androidtvwatsonfe-pa.googleapis.com
 127.0.0.1 clientmetrics-pa.googleapis.com
 
 # [googlesyndication.com]


### PR DESCRIPTION
Adding this domain blocks ads popping up in the "Android TV Home" launcher used in Android TVs or boxes like the NVIDIA Shield TV. On the later they only appeared with the latest update.

The ads take up half the homescreen and include:
- Recommendations of Movies and TV shows with links to paid apps
- Recommendations of "Staff picks" apps

When blocked, those ads are replaced by standard recommendations for YouTube, Google Play and Google Play Movies and TV (fallback). No error messages appear and no other downsides are noticeable.

More information in [this reddit thread](https://www.reddit.com/r/pihole/comments/ie5tlq/blocking_android_tvs_staff_pick_ads/).

I know that blocking `*.googleapis.com` domains can be somewhat harmful, however in the linked reddit thread no-one complained about any issues for 10 months. I've seen the domain mentioned in relation to Android TV Home ads after the latest NVIDIA Shield TV update without any complaints after beeing blocked. In my own network the domain only appeared in my logs after the latest Android TV Home update. Therefore, I think it's safe to add it.