### PR TITLE
Remove consent.trustarc.com

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -11553,7 +11553,6 @@
 
 # [trustarc.com]
 127.0.0.1 choices.trustarc.com
-127.0.0.1 consent.trustarc.com
 127.0.0.1 preferences.trustarc.com
 
 # [truste.com]


### PR DESCRIPTION
Blocking consent.trustarc.com makes SAP Concur (www.concursolutions.com) unusable.