### PR TITLE
Remove RevenueCat: does not provide ads

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -9104,9 +9104,6 @@
 127.0.0.1 publishers.revcontent.com
 127.0.0.1 trends.revcontent.com
 
-# [revenuecat.com]
-127.0.0.1 api.revenuecat.com
-
 # [revjet.com]
 127.0.0.1 ads.revjet.com
 127.0.0.1 cdn.revjet.com


### PR DESCRIPTION
Hey AdAway team! 👋🏻 I work for RevenueCat.com and we just noticed that we were added to this list.

RevenueCat is an in-app purchase processing system and is not used to serve ads to users (actually, some apps use us to let users remove ads!) Blocking our API prevents people from being able to make purchases and unlock great content and features on thousands of apps.

It would be great if we could remove RevenueCat from this list, since lots of users would be getting errors and asking for support from both RC and our customers, with us being unable to help. Actually, we have been getting some reports already that some of our customers' apps are broken because of this.

Let us know your thoughts, I’m happy to answer any questions about our service if you need it.

Thanks! 