### PR TITLE
Update hosts

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -8344,6 +8344,7 @@
 
 # [pangle.io]
 127.0.0.1 pangle.io
+127.0.0.1 api16-access-gcp.pangle.io
 127.0.0.1 api16-access-sg.pangle.io
 
 # [panickycurtain.com]
@@ -11721,6 +11722,9 @@
 
 # [wigetmedia.com]
 127.0.0.1 wigetmedia.com
+
+# [wikawika.xyz]
+127.0.0.1 ad-display.wikawika.xyz
 
 # [wildlifestudios.com]
 127.0.0.1 cads.wildlifestudios.com


### PR DESCRIPTION
1. Add api16-access-gcp.pangle.io. Ads from this host can be seen from manhuaren app.
2. Add ad-display.wikawika.xyz. Ads from this host can be seen from PicACG app. Contains NSFW ads.