### PR TITLE
add androidads4-5.adcolony.com

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -371,6 +371,7 @@
 127.0.0.1 androidads21.adcolony.com
 127.0.0.1 androidads23.adcolony.com
 127.0.0.1 androidads4-3.adcolony.com
+127.0.0.1 androidads4-5.adcolony.com
 127.0.0.1 c4d-cdn.adcolony.com
 127.0.0.1 c4dm.adcolony.com
 127.0.0.1 cpa.adcolony.com


### PR DESCRIPTION
I'm seeing traffic to androidads4-5.adcolony.com, lately.