### PR TITLE
remove healthgrades.com

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -5233,9 +5233,6 @@
 # [hbi-ingest.net]
 127.0.0.1 hbi-ingest.net
 
-# [healthgrades.com]
-127.0.0.1 www.healthgrades.com
-
 # [heapanalytics.com]
 127.0.0.1 cdn.heapanalytics.com
 


### PR DESCRIPTION
it's a legitimate site with reviews for doctors, not an ad network