### PR TITLE
Removing entries which block signing functionality in DocuSign

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -4036,12 +4036,6 @@
 127.0.0.1 bob.dmpxs.com
 127.0.0.1 ciq.dmpxs.com
 
-# [docusign.com]
-127.0.0.1 postsign.docusign.com
-
-# [docusign.net]
-127.0.0.1 telemetry.docusign.net
-
 # [doesxyz.com]
 127.0.0.1 ufz.doesxyz.com
 


### PR DESCRIPTION
The first entry is used for finalizing "signing" in the DocuSign workflow, so blocking this URL will make signing in DocuSign fail.  The second entry is used for sending back health and usage information to DocuSign for improving the product.  Neither domain is used for serving ads.

Recommend removing these so as not to break the DocuSign product.