### PR TITLE
Remove cookiebot urls from hosts.txt

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -4352,8 +4352,6 @@
 127.0.0.1 cdn-store-icons-akamai-prd.unityads.unity3d.com.edgekey.net
 127.0.0.1 vungle.com.edgekey.net
 127.0.0.1 api.vungle.com.edgekey.net
-127.0.0.1 cookiebot.com-v1.edgekey.net
-127.0.0.1 consentcdn.cookiebot.com-v1.edgekey.net
 127.0.0.1 rubiconproject.com-v1.edgekey.net
 127.0.0.1 video-ads.rubiconproject.com-v1.edgekey.net
 127.0.0.1 v6analytics.htmedia.in.edgekey.net


### PR DESCRIPTION
https://www.cookiebot.com is a CMP tool to help block/give consent to cookies and make websites compliant. It is not adware/malware.

If you have an idea as to how these urls ended up on your list, we would very much appreciate if you could let us know. That way, we can actively remedy this so it doesn't happen in the future 🙂