### PR TITLE
Remove privacyportal.onetrust.com from hosts.txt

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -8108,7 +8108,6 @@
 
 # [onetrust.com]
 127.0.0.1 geolocation.onetrust.com
-127.0.0.1 privacyportal.onetrust.com
 127.0.0.1 privacyportal-de.onetrust.com
 
 # [online-metrix.net]


### PR DESCRIPTION
privacyportal.onetrust.com hosts a CCPA request portal. It does not appear to be used for advertising.