### PR TITLE
Remove InMoment.com Domains

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -5322,11 +5322,6 @@
 127.0.0.1 glance.l.inmobicdn.net
 127.0.0.1 i.l.inmobicdn.net
 
-# [inmoment.com]
-127.0.0.1 dispawsusva.inmoment.com
-127.0.0.1 intercept.inmoment.com
-127.0.0.1 intercept-client.inmoment.com
-
 # [inner-active.mobi]
 127.0.0.1 inner-active.mobi
 127.0.0.1 ad-tag.inner-active.mobi


### PR DESCRIPTION
InMoment (www.inmoment.com) is a feedback and research company with corporate offices in Salt Lake City, Utah.  We have been mistakenly added to the Adaway list.  We do not serve any ads.  We don't collect any personal information, but we do gather some browser info to help us combat fraud by end users (maybe that is a tripping wire). Some of our programs offer an incentive for providing feedback, like a coupon, free drink, etc which have been abused in the past.  We recently have a number of client and customer complaints that our surveys are not rendering properly and our investigation led us to the addition of our domains on Adaway.   We kindly request we be removed from this list.  Thank you kindly.