### PR TITLE
Remove bskarn.com domains

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -2701,10 +2701,6 @@
 127.0.0.1 events.browsiprod.com
 127.0.0.1 yield-manager.browsiprod.com
 
-# [bskarn.com]
-127.0.0.1 cdn.bskarn.com
-127.0.0.1 loc.bskarn.com
-
 # [btloader.com]
 127.0.0.1 btloader.com
 


### PR DESCRIPTION
cdn.bskarn.com and loc.bskarn.com are required domains in order to load the "Basketball Arena" game. https://apps.apple.com/ro/app/basketball-arena-sports-game/id1491198695
Please remove those lines in order to restore connection.