### PR TITLE
Add Nextdoor UK tracking

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -7387,6 +7387,7 @@
 
 # [nextdoor.com]
 127.0.0.1 us-tracking.nextdoor.com
+127.0.0.1 uk-tracking.nextdoor.com
 
 # [nicovideo.jp]
 127.0.0.1 ads.nicovideo.jp


### PR DESCRIPTION
Add Nextdoor UK tracking domain. The equivalent US one is already on the list so I would assume this is safe (and it hasn't broken the app for me so far).