### PR TITLE
Remove Audioeye.com from adlist

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -2269,9 +2269,6 @@
 127.0.0.1 eu.y.atwola.com
 127.0.0.1 us.y.atwola.com
 
-# [audioeye.com]
-127.0.0.1 ws.audioeye.com
-
 # [auditude.com]
 127.0.0.1 ad.auditude.com
 


### PR DESCRIPTION
ws.audioeye.com should not be blocked.  Audioeye is not an advertising platform. It is a service integrated by website owners to improve accessibility to its users.  ws.audioeye.com and wsv3cdn.audioeye.com serve the files that enable this improvement in website accessibility.