### PR TITLE
add gigya.com au CDN, used on abc.net.au

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -4675,6 +4675,7 @@
 
 # [gigya.com]
 127.0.0.1 socialize.eu1.gigya.com
+127.0.0.1 cdns.au1.gigya.com
 
 # [gimbal.com]
 127.0.0.1 analytics-server.gimbal.com


### PR DESCRIPTION
`cdns.au1.gigya.com` is used for tracking on *.abc.net.au
See also https://www.youtube.com/watch?v=20bqzIoB-Fw (work on investigating abc.net.au)
