### PR TITLE
Remove socialize.eu1.gigya.com entry, breaks login

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -4808,9 +4808,6 @@
 # [getui.net]
 127.0.0.1 sdk.open.talk.getui.net
 
-# [gigya.com]
-127.0.0.1 socialize.eu1.gigya.com
-
 # [gimbal.com]
 127.0.0.1 analytics-server.gimbal.com
 127.0.0.1 communicate.gimbal.com


### PR DESCRIPTION
Blocking socialize.eu1.gigya.com breaks login on videoland.com (and probably more sites)
The us version (socialize.us1.gigya.com) is not on the list but they used to be together on adaway hosts.txt.

See issue #343 