### PR TITLE
[false positive] Remove cdn.rebuyengine.com

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -8676,9 +8676,6 @@
 # [rebel.ai]
 127.0.0.1 cdn.rebel.ai
 
-# [rebuyengine.com]
-127.0.0.1 cdn.rebuyengine.com
-
 # [recreativ.ru]
 127.0.0.1 recreativ.ru
 127.0.0.1 track.recreativ.ru


### PR DESCRIPTION
Hello 👋🏼 This entry is for rebuyengine.com's CDN, the content server for static assets for Shopify merchants, not spam, malware etc. Submitting this PR to help facilitate the removal of this false positive. Thank you!