### PR TITLE
[false positive] Remove api.agoda.com.edgekey.net

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -4213,7 +4213,6 @@
 127.0.0.1 v1.addthisedge.com.edgekey.net
 127.0.0.1 adobetag.com.edgekey.net
 127.0.0.1 san-www.adobetag.com.edgekey.net
-127.0.0.1 api.agoda.com.edgekey.net
 127.0.0.1 aniview.com.edgekey.net
 127.0.0.1 wildcard.aniview.com.edgekey.net
 127.0.0.1 wl.aniview.com.edgekey.net


### PR DESCRIPTION
hello. i found out that i unable to login Agoda application, seem it blocking by this api.agoda.com.edgekey.net. could you help to remove the false positive?