### PR TITLE
Add cdn.hubvisor.io to hosts.txt

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -4710,6 +4710,9 @@
 # [htmedia.in]
 127.0.0.1 analytics.htmedia.in
 
+# [hubvisor.io]
+127.0.0.1 cdn.hubvisor.io
+
 # [hulu.com]
 127.0.0.1 t2.hulu.com
 


### PR DESCRIPTION
Add cdn.hubvisor.io, this wrapper performs ad auctions client-side and display ads and is present on a lot of french media such as Le Figaro, Leboncoin, Altice Media, Dailymotion, 20Minutes, Cdiscount, CMI Media, Eurosport, LePoint. But also on some internationally known publishers like Kodansha.