### PR TITLE
Add cdn-ketchapp.akamaized.net

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -1351,6 +1351,7 @@
 # [akamaized.net]
 127.0.0.1 113vod-adaptive.akamaized.net
 127.0.0.1 appsflyer.com.akamaized.net
+127.0.0.1 cdn-ketchapp.akamaized.net
 127.0.0.1 jioads.akamaized.net
 127.0.0.1 speee-ad.akamaized.net
 127.0.0.1 statics-marketingsites-eus-ms-com.akamaized.net


### PR DESCRIPTION
The domain [cdn-ketchapp.akamaized.net](https://cdn-ketchapp.akamaized.net) is the cdn that provides ads for ketchapp's mobile games (tested on [Rider](https://play.google.com/store/apps/details?id=com.ketchapp.rider)). It's already in big lists such as [Adguard's](https://github.com/AdguardTeam/AdguardFilters/blob/02fbf734c38a9049cb81a7a4f6e865a5a9680f04/MobileFilter/sections/adservers.txt#L32)