### PR TITLE
Add iprom.net root domain

### DIFF
--- a/hosts.txt
+++ b/hosts.txt
@@ -5171,7 +5171,7 @@
 127.0.0.1 sync.ipredictive.com
 
 # [iprom.net]
-127.0.0.1 adserver.iprom.net
+127.0.0.1 iprom.net
 
 # [ipromote.com]
 127.0.0.1 i.ipromote.com


### PR DESCRIPTION
IProm is now using their root domain to load adds on certain websites so this PR adds the root domain to the hosts file. See attached screenshot for an example.

![Screenshot 2024-06-28 at 14 25 25](https://github.com/AdAway/adaway.github.io/assets/701239/1d525129-cd01-4cce-9cb0-37921188dfca)
